### PR TITLE
Make it build and compile on Linux.

### DIFF
--- a/Configure
+++ b/Configure
@@ -317,7 +317,7 @@ spackage=''
 prefix=''
 prefixexp=''
 prototype=''
-sh=''
+sh='/bin/bash'
 so=''
 sharpbang=''
 shsharp=''
@@ -2750,7 +2750,7 @@ echo " "
 rp="Any additional libraries?"
 . ./myread
 case "$ans" in
-none) libs=' ';;
+none) libs=' -lcrypt';;
 *) libs="$ans";;
 esac
 

--- a/makedepend.SH
+++ b/makedepend.SH
@@ -92,6 +92,7 @@ for file in `$cat .clist`; do
 	-e '/^#.*<builtin>/d' \
 	-e '/^#.*<built-in>/d' \
 	-e '/^#.*<command line>/d' \
+	-e '/^#.*<command-line>/d' \
 	-e '/^# *[0-9]/!d' \
 	-e 's/^.*"\(.*\)".*$/'$filebase'.o: \1/' \
 	-e 's|: \./|: |' \

--- a/perl.h
+++ b/perl.h
@@ -23,11 +23,6 @@
 #define VOIDUSED 1
 #include "config.h"
 
-#ifndef BCOPY
-#   define bcopy(s1,s2,l) memcpy(s2,s1,l);
-#   define bzero(s,l) memset(s,0,l);
-#endif
-
 #include <stdio.h>
 #include <ctype.h>
 #include <setjmp.h>
@@ -60,12 +55,6 @@ typedef struct htbl HASH;
 #include "cmd.h"
 #include "array.h"
 #include "hash.h"
-
-#ifdef CHARSPRINTF
-    char *sprintf();
-#else
-    int sprintf();
-#endif
 
 /* A string is TRUE if not "" or "0". */
 #define True(val) (tmps = (val), (*tmps && !(*tmps == '0' && !tmps[1])))


### PR DESCRIPTION
Issues related to building are resolved. Perl 1 compiles again and can run Perl 1 scripts.

1. Use /bin/bash instead of /bin/sh.
2. Match <command-line>, not only <command line> in the makedepend.SH file.
3. Add -lcrypt to the list of libraries.
4. Remove a few common functions declared in the perl.h. 