### PR TITLE
Add the declarations of a few functions.

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -204,3 +204,6 @@ double atof();
 #else
 #define UNLINK unlink
 #endif
+
+void arg_free(register ARG *);
+

--- a/perly.c
+++ b/perly.c
@@ -2550,7 +2550,7 @@ register CMD *cmd;
 	    break;
 	case C_EXPR:
 	    if (cmd->ucmd.acmd.ac_stab)
-		arg_free(cmd->ucmd.acmd.ac_stab);
+		arg_free((ARG *)cmd->ucmd.acmd.ac_stab);
 	    if (cmd->ucmd.acmd.ac_expr)
 		arg_free(cmd->ucmd.acmd.ac_expr);
 	    break;
@@ -2563,6 +2563,7 @@ register CMD *cmd;
     }
 }
 
+void
 arg_free(arg)
 register ARG *arg;
 {

--- a/str.c
+++ b/str.c
@@ -183,6 +183,7 @@ register STR *sstr;
 	str_ncat(dstr,sstr->str_ptr,sstr->str_cur);
 }
 
+void
 str_cat(str,ptr)
 register STR *str;
 register char *ptr;

--- a/str.h
+++ b/str.h
@@ -33,4 +33,5 @@ int str_len(register STR *);
 STR *str_new(int);
 void str_ncat(register STR *, register char *, register int);
 void str_scat(STR *, register STR *);
+void str_cat(register STR *, register char *);
 


### PR DESCRIPTION
The functions 'arg_free' and 'str_cat' tend to generate the compiler warnings. This has to be fixed. Otherwise, there's not much to do for the Perl 1 compiler.