### PR TITLE
Add the declarations of a few functions, as well as their return values.

### DIFF
--- a/str.c
+++ b/str.c
@@ -101,6 +101,7 @@ register STR *str;
     return str->str_nval;
 }
 
+void
 str_sset(dstr,sstr)
 STR *dstr;
 register STR *sstr;
@@ -115,6 +116,7 @@ register STR *sstr;
 	str_nset(dstr,"",0);
 }
 
+void
 str_nset(str,ptr,len)
 register STR *str;
 register char *ptr;
@@ -128,6 +130,7 @@ register int len;
     str->str_pok = 1;		/* validate pointer */
 }
 
+void
 str_set(str,ptr)
 register STR *str;
 register char *ptr;

--- a/str.h
+++ b/str.h
@@ -34,4 +34,7 @@ STR *str_new(int);
 void str_ncat(register STR *, register char *, register int);
 void str_scat(STR *, register STR *);
 void str_cat(register STR *, register char *);
+void str_replace(register STR *, register STR *);
+void str_nset(register STR *, register char *, register int);
+void str_sset(STR *, register STR *);
 

--- a/util.c
+++ b/util.c
@@ -79,6 +79,7 @@ MEM_SIZE size;
 
 /* safe version of free */
 
+void
 safefree(where)
 char *where;
 {

--- a/util.h
+++ b/util.h
@@ -35,4 +35,5 @@ char	*getval();
 void	growstr();
 void	setdef();
 void fatal(char *, ...);
+void safefree(char *);
 


### PR DESCRIPTION
16 compiler warnings should go away after this edit. Here are a few of them.
```
arg.c: In function ‘do_subst’:
arg.c:173:9: warning: implicit declaration of function ‘str_replace’ [-Wimplicit-function-declaration]
  173 |         str_replace(str,dstr);
      |         ^~~~~~~~~~~
arg.c: In function ‘do_split’:
arg.c:267:9: warning: implicit declaration of function ‘str_nset’; did you mean ‘str_ncat’? [-Wimplicit-function-declaration]
  267 |         str_nset(dstr,s,m-s);
      |         ^~~~~~~~
      |         str_ncat
arg.c:275:9: warning: implicit declaration of function ‘str_set’; did you mean ‘str_get’? [-Wimplicit-function-declaration]
  275 |         str_set(dstr,s);
      |         ^~~~~~~
      |         str_get
arg.c: In function ‘do_join’:
arg.c:306:5: warning: implicit declaration of function ‘str_sset’; did you mean ‘str_scat’? [-Wimplicit-function-declaration]
  306 |     str_sset(str,*elem++);
      |     ^~~~~~~~
      |     str_scat
arg.c:312:5: warning: implicit declaration of function ‘safefree’ [-Wimplicit-function-declaration]
  312 |     safefree((char*)tmpary);
      |     ^~~~~~~~
```