### PR TITLE
Include the declarations of 'str_set', 'unlink', and 'link' function.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -534,6 +534,7 @@ int whence;
     return fseek(stio->fp, pos, whence) >= 0;
 }
 
+int
 do_stat(arg,sarg,retary)
 register ARG *arg;
 register STR **sarg;
@@ -590,6 +591,7 @@ STR ***retary;
     return max;
 }
 
+int
 do_tms(retary)
 STR ***retary;
 {
@@ -623,6 +625,7 @@ STR ***retary;
     return max;
 }
 
+int
 do_time(tmbuf,retary)
 struct tm *tmbuf;
 STR ***retary;

--- a/perl.h
+++ b/perl.h
@@ -36,6 +36,7 @@
 #endif
 
 #include <sys/times.h>
+#include <unistd.h>
 
 typedef struct arg ARG;
 typedef struct cmd CMD;

--- a/perly.c
+++ b/perly.c
@@ -188,8 +188,12 @@ register char **env;
     sigstab = stabent("SIG",allstabs);
 
     magicalize("!#?^~=-%0123456789.+&*(),\\/[|");
+    tmpstab = stabent("0",allstabs);
 
-    (tmpstab = stabent("0",allstabs)) && str_set(STAB_STR(tmpstab),filename);
+    if (tmpstab) {
+	str_set(STAB_STR(tmpstab),filename);
+    }
+
     (tmpstab = stabent("$",allstabs)) &&
 	str_numset(STAB_STR(tmpstab),(double)getpid());
 

--- a/str.h
+++ b/str.h
@@ -37,4 +37,5 @@ void str_cat(register STR *, register char *);
 void str_replace(register STR *, register STR *);
 void str_nset(register STR *, register char *, register int);
 void str_sset(STR *, register STR *);
+void str_set(register STR *, register char *);
 


### PR DESCRIPTION
There were also a few return types to add. Here's how the compiler warnings looked like.
```
arg.c: In function ‘do_split’:
arg.c:275:9: warning: implicit declaration of function ‘str_set’; did you mean ‘str_sset’? [-Wimplicit-function-declaration]
  275 |         str_set(dstr,s);
      |         ^~~~~~~
      |         str_sset
In file included from arg.c:34:
arg.c: In function ‘nextargv’:
perl.h:205:16: warning: implicit declaration of function ‘unlink’ [-Wimplicit-function-declaration]
  205 | #define UNLINK unlink
      |                ^~~~~~
arg.c:418:21: note: in expansion of macro ‘UNLINK’
  418 |                     UNLINK(str->str_ptr);
      |                     ^~~~~~
arg.c:419:21: warning: implicit declaration of function ‘link’ [-Wimplicit-function-declaration]
  419 |                     link(oldname,str->str_ptr);
      |                     ^~~~
arg.c: At top level:
arg.c:537:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  537 | do_stat(arg,sarg,retary)
      | ^~~~~~~
arg.c:593:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  593 | do_tms(retary)
      | ^~~~~~
arg.c:626:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  626 | do_time(tmbuf,retary)
      | ^~~~~~~
```