### PR TITLE
Remove the compiler warnings caused by a few functions.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -870,6 +870,7 @@ register ARRAY *ary;
     return str;
 }
 
+void
 do_unshift(arg,ary)
 register ARG *arg;
 register ARRAY *ary;
@@ -893,6 +894,7 @@ register ARRAY *ary;
     safefree((char*)tmpary);
 }
 
+int
 apply(type,arg,sarg)
 int type;
 register ARG *arg;
@@ -956,7 +958,7 @@ STR **sarg;
 STR *
 do_subr(arg,sarg)
 register ARG *arg;
-register char **sarg;
+register STR **sarg;
 {
     ARRAY *savearray;
     STR *str;

--- a/array.c
+++ b/array.c
@@ -114,6 +114,7 @@ register ARRAY *ar;
     return retval;
 }
 
+void
 aunshift(ar,num)
 register ARRAY *ar;
 register int num;

--- a/array.h
+++ b/array.h
@@ -20,3 +20,5 @@ STR *ashift();
 bool apush();
 long alen();
 ARRAY *anew();
+void aunshift(register ARRAY *, register int);
+


### PR DESCRIPTION
Here are the compiler warnings removed.
```
arg.c:873:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  873 | do_unshift(arg,ary)
      | ^~~~~~~~~~
arg.c: In function ‘do_unshift’:
arg.c:886:5: warning: implicit declaration of function ‘aunshift’; did you mean ‘ashift’? [-Wimplicit-function-declaration]
  886 |     aunshift(ary,i);
      |     ^~~~~~~~
      |     ashift
arg.c: At top level:
arg.c:896:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  896 | apply(type,arg,sarg)
      | ^~~~~
arg.c: In function ‘do_subr’:
arg.c:970:26: warning: passing argument 2 of ‘str_sset’ from incompatible pointer type [-Wincompatible-pointer-types]
  970 |         str_sset(str,sarg[1]);
      |                      ~~~~^~~
      |                          |
      |                          char *
```