### PR TITLE
Remove the compiler warnings.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -1111,6 +1111,7 @@ STR ***retary;
     return retstr;
 }
 
+void
 init_eval()
 {
     register int i;

--- a/array.h
+++ b/array.h
@@ -21,4 +21,5 @@ bool apush();
 long alen();
 ARRAY *anew();
 void aunshift(register ARRAY *, register int);
+void afree(register ARRAY *);
 

--- a/perly.c
+++ b/perly.c
@@ -194,8 +194,11 @@ register char **env;
 	str_set(STAB_STR(tmpstab),filename);
     }
 
-    (tmpstab = stabent("$",allstabs)) &&
+    tmpstab = stabent("$",allstabs);
+
+    if (tmpstab) {
 	str_numset(STAB_STR(tmpstab),(double)getpid());
+    }
 
     tmpstab = stabent("stdin",TRUE);
     tmpstab->stab_io = stio_new();

--- a/str.c
+++ b/str.c
@@ -50,6 +50,7 @@ register char *s;
     }
 }
 
+void
 str_numset(str,num)
 register STR *str;
 double num;

--- a/str.h
+++ b/str.h
@@ -38,4 +38,6 @@ void str_replace(register STR *, register STR *);
 void str_nset(register STR *, register char *, register int);
 void str_sset(STR *, register STR *);
 void str_set(register STR *, register char *);
+void str_numset(register STR *, double);
+void str_inc(register STR *);
 


### PR DESCRIPTION
Several more functions caused warnings. Those are:
- afree
- str_numset
- init_eval
- str_inc

```
arg.c: In function ‘do_subr’:
arg.c:976:5: warning: implicit declaration of function ‘afree’; did you mean ‘free’? [-Wimplicit-function-declaration]
  976 |     afree(defstab->stab_array);  /* put back old $_[] */
      |     ^~~~~
      |     free
arg.c: In function ‘do_assign’:
arg.c:1035:5: warning: implicit declaration of function ‘str_numset’; did you mean ‘str_nset’? [-Wimplicit-function-declaration]
 1035 |     str_numset(retstr,(double)i);
      |     ^~~~~~~~~~
      |     str_nset
arg.c: At top level:
arg.c:1114:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
 1114 | init_eval()
      | ^~~~~~~~~
arg.c: In function ‘eval’:
arg.c:1337:21: warning: implicit declaration of function ‘str_inc’ [-Wimplicit-function-declaration]
 1337 |                     str_inc(str);
      |                     ^~~~~~~
```