### PR TITLE
Remove a few compiler warnings.

### DIFF
--- a/form.c
+++ b/form.c
@@ -23,6 +23,7 @@ if (d - orec->o_str + (allow) >= curlen) { \
     curlen = orec->o_len - 2; \
 }
 
+void
 format(orec,fcmd)
 register struct outrec *orec;
 register FCMD *fcmd;

--- a/form.h
+++ b/form.h
@@ -27,3 +27,15 @@ struct formcmd {
 #define FC_MORE 4
 
 #define Nullfcmd Null(FCMD*)
+
+struct outrec {
+    int o_lines;
+    char *o_str;
+    int o_len;
+};
+
+EXT struct outrec outrec;
+EXT struct outrec toprec;
+
+void format(register struct outrec *, register FCMD *);
+

--- a/perl.h
+++ b/perl.h
@@ -126,15 +126,6 @@ void freearg();
 EXT int line INIT(0);
 EXT int arybase INIT(0);
 
-struct outrec {
-    int o_lines;
-    char *o_str;
-    int o_len;
-};
-
-EXT struct outrec outrec;
-EXT struct outrec toprec;
-
 EXT STAB *last_in_stab INIT(Nullstab);
 EXT STAB *defstab INIT(Nullstab);
 EXT STAB *argvstab INIT(Nullstab);


### PR DESCRIPTION
Today's set of the functions that caused the warnings:
- str_dec
- str_set
- format.

Here comes the corresponding compiler output.
```
arg.c: In function ‘eval’:
arg.c:1340:21: warning: implicit declaration of function ‘str_dec’; did you mean ‘str_inc’? [-Wimplicit-function-declaration]
 1340 |                     str_dec(str);
      |                     ^~~~~~~
      |                     str_inc
arg.c:1603:34: warning: passing argument 2 of ‘str_set’ from incompatible pointer type [-Wincompatible-pointer-types]
 1603 |                 str_set(str, sarg[1]);
      |                              ~~~~^~~
      |                                  |
      |                                  STR * {aka struct string *}
In file included from perl.h:51,
                 from arg.c:34:
str.h:40:30: note: expected ‘char *’ but argument is of type ‘STR *’ {aka ‘struct string *’}
   40 | void str_set(register STR *, register char *);
      |                              ^~~~~~~~~~~~~~~
arg.c:1670:9: warning: implicit declaration of function ‘format’ [-Wimplicit-function-declaration]
 1670 |         format(&outrec,form);
      |         ^~~~~~
```