### PR TITLE
Remove the compiler warnings caused by the 'str_dec', 'str_set', and 'do_write'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -1600,7 +1600,7 @@ STR ***retary;		/* where to return an array to, null if nowhere */
     case O_OR:
 	if (str_true(sarg[1])) {
 	    if (assigning) {
-		str_set(str, sarg[1]);
+		str_set(str, str_get(sarg[1]));
 		STABSET(str);
 	    }
 	    else

--- a/array.h
+++ b/array.h
@@ -22,4 +22,5 @@ long alen();
 ARRAY *anew();
 void aunshift(register ARRAY *, register int);
 void afree(register ARRAY *);
+void ajoin(register ARRAY *, char *, register STR *);
 

--- a/form.c
+++ b/form.c
@@ -234,6 +234,7 @@ register char *s;
     return count;
 }
 
+void
 do_write(orec,stio)
 struct outrec *orec;
 register STIO *stio;

--- a/form.h
+++ b/form.h
@@ -38,4 +38,5 @@ EXT struct outrec outrec;
 EXT struct outrec toprec;
 
 void format(register struct outrec *, register FCMD *);
+void do_write(struct outrec *, register STIO *);
 

--- a/str.h
+++ b/str.h
@@ -40,4 +40,5 @@ void str_sset(STR *, register STR *);
 void str_set(register STR *, register char *);
 void str_numset(register STR *, double);
 void str_inc(register STR *);
+void str_dec(register STR *);
 


### PR DESCRIPTION
This time those compiler warnings are eliminated.
```
arg.c: In function ‘eval’:
arg.c:1340:21: warning: implicit declaration of function ‘str_dec’; did you mean ‘str_inc’? [-Wimplicit-function-declaration]
 1340 |                     str_dec(str);
      |                     ^~~~~~~
      |                     str_inc
arg.c:1603:34: warning: passing argument 2 of ‘str_set’ from incompatible pointer type [-Wincompatible-pointer-types]
 1603 |                 str_set(str, sarg[1]);
      |                              ~~~~^~~
      |                                  |
      |                                  STR * {aka struct string *}
In file included from perl.h:51,
                 from arg.c:34:
str.h:40:30: note: expected ‘char *’ but argument is of type ‘STR *’ {aka ‘struct string *’}
   40 | void str_set(register STR *, register char *);
      |                              ^~~~~~~~~~~~~~~
arg.c:1671:9: warning: implicit declaration of function ‘do_write’ [-Wimplicit-function-declaration]
 1671 |         do_write(&outrec,stab->stab_io);
      |         ^~~~~~~~
```