### PR TITLE
Remove the compiler warnings caused by the 'str_reset', 'wait', and 'safefree'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <string.h>
+#include <sys/wait.h>
 #include "handy.h"
 #include "EXTERN.h"
 #include "search.h"
@@ -2161,7 +2162,7 @@ freeargs:
 	    *retary = sarg;	/* up to them to free it */
 	}
 	else
-	    safefree(sarg);
+	    safefree((char *)sarg);
     }
     return str;
 

--- a/cmd.c
+++ b/cmd.c
@@ -449,6 +449,7 @@ void deb(char *pat, ...)
 }
 #endif
 
+short
 copyopt(cmd,which)
 register CMD *cmd;
 register CMD *which;

--- a/cmd.h
+++ b/cmd.h
@@ -125,4 +125,5 @@ void opt_arg();
 void evalstatic();
 STR *cmd_exec();
 void deb(char *pat, ...);
+short copyopt(register CMD *, register CMD *);
 

--- a/str.c
+++ b/str.c
@@ -15,6 +15,7 @@
 #include "util.h"
 #include "perl.h"
 
+void
 str_reset(s)
 register char *s;
 {

--- a/str.h
+++ b/str.h
@@ -41,4 +41,6 @@ void str_set(register STR *, register char *);
 void str_numset(register STR *, double);
 void str_inc(register STR *);
 void str_dec(register STR *);
+void str_reset(register char *);
+void str_grow(register STR *, int);
 


### PR DESCRIPTION
Here's a list of compiler warnings.
```
cc -c -fpcc-struct-return -I/usr/local/include -O  arg.c
arg.c: In function ‘eval’:
arg.c:1890:9: warning: implicit declaration of function ‘str_reset’; did you mean ‘str_set’? [-Wimplicit-function-declaration]
 1890 |         str_reset(str_get(sarg[1]));
      |         ^~~~~~~~~
      |         str_set
arg.c:2033:30: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
 2033 |             while ((maxarg = wait(&argflags)) != anum && maxarg != -1)
      |                              ^~~~
arg.c:2164:22: warning: passing argument 1 of ‘safefree’ from incompatible pointer type [-Wincompatible-pointer-types]
 2164 |             safefree(sarg);
      |                      ^~~~
      |                      |
      |                      STR ** {aka struct string **}
In file included from arg.c:33:
util.h:38:15: note: expected ‘char *’ but argument is of type ‘STR **’ {aka ‘struct string **’}
   38 | void safefree(char *);
      |               ^~~~~~
cc -c -fpcc-struct-return -I/usr/local/include -O  array.c
array.c: In function ‘ajoin’:
array.c:177:5: warning: implicit declaration of function ‘str_grow’ [-Wimplicit-function-declaration]
  177 |     str_grow(str,len);                  /* preallocate for efficiency */
      |     ^~~~~~~~
```