### PR TITLE
Fix the warnings caused by the functions: 'dump_cmd', 'dump', 'dump_stab' and 'dump_arg'.

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -16,6 +16,22 @@
 #ifdef DEBUGGING
 static int dumplvl = 0;
 
+void dump_stab(register STAB *);
+void dump_spat(register SPAT *);
+void dump_arg(register ARG *);
+
+void
+dump(arg1,arg2,arg3,arg4,arg5)
+char *arg1, *arg2, *arg3, *arg4, *arg5;
+{
+    int i;
+
+    for (i = dumplvl*4; i; i--)
+	putc(' ',stderr);
+    fprintf(stderr,arg1, arg2, arg3, arg4, arg5);
+}
+
+void
 dump_cmd(cmd,alt)
 register CMD *cmd;
 register CMD *alt;
@@ -109,6 +125,7 @@ register CMD *alt;
     }
 }
 
+void
 dump_arg(arg)
 register ARG *arg;
 {
@@ -175,6 +192,7 @@ register ARG *arg;
     dump("}\n");
 }
 
+void
 dump_stab(stab)
 register STAB *stab;
 {
@@ -185,6 +203,7 @@ register STAB *stab;
     dump("}\n");
 }
 
+void
 dump_spat(spat)
 register SPAT *spat;
 {
@@ -210,15 +229,6 @@ register SPAT *spat;
     dump("}\n");
 }
 
-dump(arg1,arg2,arg3,arg4,arg5)
-char *arg1, *arg2, *arg3, *arg4, *arg5;
-{
-    int i;
-
-    for (i = dumplvl*4; i; i--)
-	putc(' ',stderr);
-    fprintf(stderr,arg1, arg2, arg3, arg4, arg5);
-}
 #endif
 
 #ifdef DEBUG


### PR DESCRIPTION
Here are the compiler warnings.
```
dump.c:19:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
   19 | dump_cmd(cmd,alt)
      | ^~~~~~~~
dump.c: In function ‘dump_cmd’:
dump.c:26:9: warning: implicit declaration of function ‘dump’; did you mean ‘dup’? [-Wimplicit-function-declaration]
   26 |         dump("C_TYPE = %s\n",cmdname[cmd->c_type]);
      |         ^~~~
      |         dup
dump.c:56:13: warning: implicit declaration of function ‘dump_stab’ [-Wimplicit-function-declaration]
   56 |             dump_stab(cmd->c_stab);
      |             ^~~~~~~~~
dump.c:60:13: warning: implicit declaration of function ‘dump_spat’ [-Wimplicit-function-declaration]
   60 |             dump_spat(cmd->c_spat);
      |             ^~~~~~~~~
dump.c:64:13: warning: implicit declaration of function ‘dump_arg’ [-Wimplicit-function-declaration]
   64 |             dump_arg(cmd->c_expr);
      |             ^~~~~~~~
dump.c: At top level:
dump.c:112:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  112 | dump_arg(arg)
      | ^~~~~~~~
dump.c:178:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  178 | dump_stab(stab)
      | ^~~~~~~~~
dump.c:188:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  188 | dump_spat(spat)
      | ^~~~~~~~~
dump.c:213:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  213 | dump(arg1,arg2,arg3,arg4,arg5)
      | ^~~~
```