### PR TITLE
Fix a few compiler warnings.

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -16,7 +16,7 @@
 #include "util.h"
 #include "perl.h"
 
-static STR str_chop;
+static STR str_chop_var;
 
 /* This is the main command loop.  We try to spend as much time in this loop
  * as possible, so lots of optimizations do their activities in here.  This
@@ -272,11 +272,11 @@ until_loop:
 	    match = (retstr->str_cur != 0);
 	    tmps = str_get(retstr);
 	    tmps += retstr->str_cur - match;
-	    str_set(&str_chop,tmps);
+	    str_set(&str_chop_var,tmps);
 	    *tmps = '\0';
 	    retstr->str_nok = 0;
 	    retstr->str_cur = tmps - retstr->str_ptr;
-	    retstr = &str_chop;
+	    retstr = &str_chop_var;
 	    goto flipmaybe;
 	}
 

--- a/dump.c
+++ b/dump.c
@@ -98,7 +98,7 @@ register CMD *alt;
 	case C_EXPR:
 	    if (cmd->ucmd.acmd.ac_stab) {
 		dump("AC_STAB = ");
-		dump_arg(cmd->ucmd.acmd.ac_stab);
+		dump_stab(cmd->ucmd.acmd.ac_stab);
 	    } else
 		dump("AC_STAB = NULL\n");
 	    if (cmd->ucmd.acmd.ac_expr) {

--- a/form.c
+++ b/form.c
@@ -23,6 +23,19 @@ if (d - orec->o_str + (allow) >= curlen) { \
     curlen = orec->o_len - 2; \
 }
 
+int
+countlines(s)
+register char *s;
+{
+    register int count = 0;
+
+    while (*s) {
+        if (*s++ == '\n')
+            count++;
+    }
+    return count;
+}
+
 void
 format(orec,fcmd)
 register struct outrec *orec;
@@ -220,18 +233,6 @@ register FCMD *fcmd;
 	}
     }
     *d++ = '\0';
-}
-
-countlines(s)
-register char *s;
-{
-    register int count = 0;
-
-    while (*s) {
-	if (*s++ == '\n')
-	    count++;
-    }
-    return count;
 }
 
 void

--- a/str.c
+++ b/str.c
@@ -149,6 +149,7 @@ register char *ptr;
     str->str_pok = 1;		/* validate pointer */
 }
 
+void
 str_chop(str,ptr)	/* like set but assuming ptr is in str */
 register STR *str;
 register char *ptr;

--- a/str.h
+++ b/str.h
@@ -43,4 +43,5 @@ void str_inc(register STR *);
 void str_dec(register STR *);
 void str_reset(register char *);
 void str_grow(register STR *, int);
+void str_chop(register STR *, register char *);
 


### PR DESCRIPTION
- Fix the warnings caused by the functions: 'dump_arg', 'str_chop', and 'countlines'.
- Replace 'dump_arg' with 'dump_stab' to fix a compiler warning.

```
dump.c: In function ‘dump_cmd’:
dump.c:101:40: warning: passing argument 1 of ‘dump_arg’ from incompatible pointer type [-Wincompatible-pointer-types]
  101 |                 dump_arg(cmd->ucmd.acmd.ac_stab);
      |                          ~~~~~~~~~~~~~~^~~~~~~~
      |                                        |
      |                                        STAB * {aka struct stab *}
dump.c:21:15: note: expected ‘ARG *’ {aka ‘struct arg *’} but argument is of type ‘STAB *’ {aka ‘struct stab *’}
   21 | void dump_arg(register ARG *);
      |               ^~~~~~~~~~~~~~
cc -c -fpcc-struct-return -I/usr/local/include -O  form.c
form.c: In function ‘format’:
form.c:96:17: warning: implicit declaration of function ‘str_chop’ [-Wimplicit-function-declaration]
   96 |                 str_chop(str,chophere);
      |                 ^~~~~~~~
form.c:216:30: warning: implicit declaration of function ‘countlines’ [-Wimplicit-function-declaration]
  216 |             orec->o_lines += countlines(s);
      |                              ^~~~~~~~~~
form.c: At top level:
form.c:225:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  225 | countlines(s)
      | ^~~~~~~~~~
```