### PR TITLE
Add the int return type to the 'hiterinit' function.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -192,6 +192,7 @@ register HASH *tb;
 }
 #endif
 
+int
 hiterinit(tb)
 register HASH *tb;
 {


### PR DESCRIPTION
A compiler warning has to be fixed.
```
hash.c:195:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  195 | hiterinit(tb)
      | ^~~~~~~~~
```