### PR TITLE
Add a missing argument type to the 'cclass' function.

### DIFF
--- a/search.c
+++ b/search.c
@@ -742,6 +742,7 @@ bool
 cclass(set, c, af)
 register char  *set;
 register int c;
+register int af;
 {
     c &= 0177;
 #if BITSPERBYTE == 8


### PR DESCRIPTION
It'd fixed this compiler warning.
```
search.c: In function ‘cclass’:
search.c:742:1: warning: type of ‘af’ defaults to ‘int’ [-Wimplicit-int]
  742 | cclass(set, c, af)
      | ^~~~~~
```