### PR TITLE
Add a missing header file.

### DIFF
--- a/stab.c
+++ b/stab.c
@@ -12,6 +12,7 @@
  * 
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include <signal.h>
 #include <errno.h>


### PR DESCRIPTION
Including 'stdlib.h' in the stab.c file fixes a compiler warning.
```
stab.c: In function ‘stab_str’:
stab.c:83:21: warning: implicit declaration of function ‘atoi’; did you mean ‘atof’? [-Wimplicit-function-declaration]
   83 |             paren = atoi(stab->stab_name);
      |                     ^~~~
      |                     atof
```