### PR TITLE
Fix the warnings related to the 'version()' function.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -17,6 +17,7 @@ char rcsid[] = "$Header: perly.c,v 1.0.1.3 88/01/28 10:28:31 root Exp $";
 
 #include <stdlib.h>
 #include <string.h>
+#include "version.h"
 
 bool preprocess = FALSE;
 bool assume_n = FALSE;

--- a/version.c
+++ b/version.c
@@ -11,6 +11,7 @@
 
 /* Print out the version number. */
 
+void
 version()
 {
     extern char rcsid[];

--- a/version.h
+++ b/version.h
@@ -1,0 +1,3 @@
+/* Print out the version number. */
+void version();
+


### PR DESCRIPTION
The declaration of the 'version()' function has to be wherever needed.
```
version.c:14:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
   14 | version()
      | ^~~~~~~
perly.c: In function ‘main’:
perly.c:96:13: warning: implicit declaration of function ‘version’ [-Wimplicit-function-declaration]
   96 |             version();
      |             ^~~~~~~
```