### PR TITLE
Add a return type of the 'main()' function.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -29,6 +29,7 @@ char *e_tmpname = "/tmp/perl-eXXXXXX";
 FILE *e_fp = Nullfp;
 ARG *l();
 
+int
 main(argc,argv,env)
 register int argc;
 register char **argv;
@@ -233,6 +234,7 @@ register char **env;
     if (goto_targ)
 	fatal("Can't find label \"%s\"--aborting.\n",goto_targ);
     exit(0);
+    return 0;
 }
 
 magicalize(list)


### PR DESCRIPTION
Replace the default return type with an explicit 'int'.
```
perly.c:32:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
   32 | main(argc,argv,env)
      | ^~~~
```