### PR TITLE
Declare the 'init_eval' function before its use.

### DIFF
--- a/arg.h
+++ b/arg.h
@@ -317,3 +317,5 @@ bool do_seek();
 int do_tms();
 int do_time();
 int do_stat();
+void init_eval();
+


### PR DESCRIPTION
This compiler warning wouldn't happen if the functions were declared before use.
```
perly.c: In function ‘main’:
perly.c:118:5: warning: implicit declaration of function ‘init_eval’ [-Wimplicit-function-declaration]
  118 |     init_eval();
      |     ^~~~~~~~~
```