### PR TITLE
Declare the 'magicalize' function before its use.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -29,6 +29,8 @@ char *e_tmpname = "/tmp/perl-eXXXXXX";
 FILE *e_fp = Nullfp;
 ARG *l();
 
+void magicalize(register char *);
+
 int
 main(argc,argv,env)
 register int argc;
@@ -237,6 +239,7 @@ register char **env;
     return 0;
 }
 
+void
 magicalize(list)
 register char *list;
 {


### PR DESCRIPTION
As often, an undeclared function can trigger a compiler warning. 
```
perly.c: In function ‘main’:
perly.c:192:5: warning: implicit declaration of function ‘magicalize’ [-Wimplicit-function-declaration]
  192 |     magicalize("!#?^~=-%0123456789.+&*(),\\/[|");
      |     ^~~~~~~~~~
perly.c: At top level:
perly.c:240:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  240 | magicalize(list)
      | ^~~~~~~~~~
```