### PR TITLE
Add the 'dump.h' header file.

### DIFF
--- a/dump.h
+++ b/dump.h
@@ -1,0 +1,2 @@
+void dump_cmd(register CMD *, register CMD *);
+

--- a/perly.c
+++ b/perly.c
@@ -17,6 +17,7 @@ char rcsid[] = "$Header: perly.c,v 1.0.1.3 88/01/28 10:28:31 root Exp $";
 
 #include <stdlib.h>
 #include <string.h>
+#include "dump.h"
 #include "version.h"
 
 bool preprocess = FALSE;


### PR DESCRIPTION
A new header file was required to get rid of a compiler warning.
```
perly.c: In function ‘main’:
perly.c:227:9: warning: implicit declaration of function ‘dump_cmd’ [-Wimplicit-function-declaration]
  227 |         dump_cmd(main_root,Nullcmd);
      |         ^~~~~~~~
```