### PR TITLE
Add a return type of the 'yylex()' function.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -267,6 +267,7 @@ register char *list;
 #define FUN3(f) return (yylval.ival = f,expectterm = FALSE,bufptr = s,FUNC3)
 #define SFUN(f) return (yylval.ival = f,expectterm = FALSE,bufptr = s,STABFUN)
 
+int
 yylex()
 {
     register char *s = bufptr;


### PR DESCRIPTION
There are still more compiler warnings left to fix.
```
In file included from perl.y:595:
perly.c:270:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  270 | yylex()
      | ^~~~~
```