### PR TITLE
Add a missing argument type to the 'mod_match' function.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1386,9 +1386,7 @@ int fliporflop;
 }
 
 ARG *
-mod_match(type,left,pat)
-register ARG *left;
-register ARG *pat;
+mod_match(int type, register ARG *left, register ARG *pat)
 {
 
     register SPAT *spat;


### PR DESCRIPTION
Declare an argument type instead of leaving the default.
```
perly.c: In function ‘mod_match’:
perly.c:1389:1: warning: type of ‘type’ defaults to ‘int’ [-Wimplicit-int]
 1389 | mod_match(type,left,pat)
      | ^~~~~~~~~
```