### PR TITLE
Fix a few compiler warnings.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -31,6 +31,8 @@ FILE *e_fp = Nullfp;
 ARG *l();
 
 void magicalize(register char *);
+void cmd_free(register CMD *cmd);
+void spat_free(register SPAT *spat);
 
 int
 main(argc,argv,env)
@@ -1498,6 +1500,7 @@ register CMD *cmd;
     return cmd;
 }
 
+void
 yyerror(s)
 char *s;
 {
@@ -2162,6 +2165,8 @@ register ARG *arg;
 
 ARG *
 addflags(i,flags,arg)
+register int i;
+register int flags;
 register ARG *arg;
 {
     arg[i].arg_flags |= flags;
@@ -2537,6 +2542,7 @@ STR *str;
     return str;
 }
 
+void
 cmd_free(cmd)
 register CMD *cmd;
 {
@@ -2559,7 +2565,7 @@ register CMD *cmd;
 	    if (cmd->ucmd.ccmd.cc_true)
 		cmd_free(cmd->ucmd.ccmd.cc_true);
 	    if (cmd->c_type == C_IF && cmd->ucmd.ccmd.cc_alt)
-		cmd_free(cmd->ucmd.ccmd.cc_alt,Nullcmd);
+		cmd_free(cmd->ucmd.ccmd.cc_alt);
 	    break;
 	case C_EXPR:
 	    if (cmd->ucmd.acmd.ac_stab)
@@ -2613,6 +2619,7 @@ register ARG *arg;
     free_arg(arg);
 }
 
+void
 spat_free(spat)
 register SPAT *spat;
 {


### PR DESCRIPTION
Fix the remaining compiler warnings. After this update, it compiles without a warning.
```
In file included from perl.y:595:
perly.c:1501:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
 1501 | yyerror(s)
      | ^~~~~~~
perly.c: In function ‘addflags’:
perly.c:2164:1: warning: type of ‘i’ defaults to ‘int’ [-Wimplicit-int]
 2164 | addflags(i,flags,arg)
      | ^~~~~~~~
perly.c:2164:1: warning: type of ‘flags’ defaults to ‘int’ [-Wimplicit-int]
perly.c: In function ‘do_eval’:
perly.c:2534:9: warning: implicit declaration of function ‘cmd_free’ [-Wimplicit-function-declaration]
 2534 |         cmd_free(myroot);       /* can't free on error, for some reason */
      |         ^~~~~~~~
perly.c: At top level:
perly.c:2540:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
 2540 | cmd_free(cmd)
      | ^~~~~~~~
perly.c: In function ‘cmd_free’:
perly.c:2552:13: warning: implicit declaration of function ‘spat_free’; did you mean ‘str_free’? [-Wimplicit-function-declaration]
 2552 |             spat_free(cmd->c_spat);
      |             ^~~~~~~~~
      |             str_free
perly.c: At top level:
perly.c:2616:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
 2616 | spat_free(spat)
      | ^~~~~~~~~
```